### PR TITLE
fix: use `effectiveCanisterId` in certificate verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix(agent): use the `effectiveCanisterId` instead of the `canisterId` to verify the certificate of an update call.
+
 ## [4.0.1] - 2025-08-26
 
 - fix(candid): avoid removing shared knot types when multiple `Rec()`s are present in the same struct.

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -45,7 +45,7 @@ export interface CallConfig {
   canisterId?: string | Principal;
 
   /**
-   * The effective canister ID. This should almost always be ignored.
+   * The effective canister ID.
    */
   effectiveCanisterId?: Principal;
 
@@ -426,7 +426,7 @@ function _createActorMethod(
         certificate = await Certificate.create({
           certificate: cert,
           rootKey: agent.rootKey,
-          canisterId: Principal.from(canisterId),
+          canisterId: ecid,
           blsVerify,
           agent,
         });


### PR DESCRIPTION
# Description

Uses the `effectiveCanisterId` to verify certificate returned from an update call.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
