### PR TITLE
fix: DelegationChain's `toJSON` failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix(identity): `DelegationChain`'s `toJSON` failing silently.
+
 ## [4.0.4] - 2025-09-18
 
 - fix(agent): create a fresh default polling strategy per request.

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -246,10 +246,10 @@ export class DelegationChain {
               targets: targets.map(t => t.toHex()),
             }),
           },
-          signature: bytesToHex(signature),
+          signature: bytesToHex(new Uint8Array(signature)),
         };
       }),
-      publicKey: bytesToHex(this.publicKey),
+      publicKey: bytesToHex(new Uint8Array(this.publicKey)),
     };
   }
 }


### PR DESCRIPTION
# Description

`DelegationChain`'s `toJSON` method is failing silently.



# How Has This Been Tested?

In Internet Identity we were relying on this method to check some properties during E2E tests and they started failing when we upgraded to the latest version (4).

With the changes proposed here, our test application was able to create the JSON text and the E2E are passing again.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
