### PR TITLE
feat(agent): load root key from `ic_env` cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(agent): load root key from the `ic_env` cookie if no root key is specified and `shouldFetchRootKey` is false.
 - feat(agent): introduce the `getCanisterEnv` and `safeGetCanisterEnv` functions to load the canister environment from the `ic_env` cookie.
 
 ## [4.0.5] - 2025-09-30


### PR DESCRIPTION
# Description

Load root key from the `ic_env` cookie if no root key is specified and `shouldFetchRootKey` is false.

Blocked by #1156.

# How Has This Been Tested?

Added unit tests.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
