### PR TITLE
fix(agent): detect conflicting `ic_env` cookies instead of taking the first

### DIFF
--- a/packages/core/src/agent/canister-env/index.test.ts
+++ b/packages/core/src/agent/canister-env/index.test.ts
@@ -7,6 +7,7 @@ import {
   MissingRootKeyErrorCode,
   MissingCookieErrorCode,
   ConflictingCanisterEnvErrorCode,
+  MalformedCookieErrorCode,
 } from '../errors.ts';
 import { JSDOM } from 'jsdom';
 
@@ -203,7 +204,7 @@ describe('getCanisterEnv', () => {
           expect(error).toBeInstanceOf(InputError);
           expect((error as InputError).code).toBeInstanceOf(ConflictingCanisterEnvErrorCode);
           expect((error as ConflictingCanisterEnvErrorCode & InputError).message).toContain(
-            "Found 2 'ic_env' cookies with conflicting values",
+            "Found 2 conflicting values for the 'ic_env' cookie",
           );
           expect((error as InputError).code).toHaveProperty('values', [stale, fresh]);
         }
@@ -220,6 +221,58 @@ describe('getCanisterEnv', () => {
         const env = getCanisterEnv();
 
         expect(bytesToHex(env.IC_ROOT_KEY)).toBe(mockRootKeyHex);
+      });
+
+      test('should report the number of distinct environments, not the number of cookies', () => {
+        const stale = encodeURIComponent(`ic_root_key=${mockRootKeyHex}&PUBLIC_ID=stale`);
+        const fresh = encodeURIComponent(`ic_root_key=${mockRootKeyHex}&PUBLIC_ID=fresh`);
+
+        // Three cookies, two environments.
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=${stale}; ic_env=${fresh}; ic_env=${fresh}`,
+        });
+
+        expect.assertions(1);
+        try {
+          getCanisterEnv();
+        } catch (error) {
+          expect((error as InputError).message).toContain(
+            "Found 2 conflicting values for the 'ic_env' cookie",
+          );
+        }
+      });
+
+      test('should ignore a copy with malformed encoding when a valid one is present', () => {
+        const cookieValue = `ic_root_key=${mockRootKeyHex}`;
+
+        // `%E0%A4%A` is a truncated percent-escape; `decodeURIComponent` throws `URIError` on it.
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=%E0%A4%A; ic_env=${encodeURIComponent(cookieValue)}`,
+        });
+
+        const env = getCanisterEnv();
+
+        expect(bytesToHex(env.IC_ROOT_KEY)).toBe(mockRootKeyHex);
+      });
+
+      test('should throw an InputError, not a URIError, when no copy can be decoded', () => {
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=%E0%A4%A; ic_env=%`,
+        });
+
+        expect.assertions(3);
+        try {
+          getCanisterEnv();
+        } catch (error) {
+          expect(error).toBeInstanceOf(InputError);
+          expect((error as InputError).code).toBeInstanceOf(MalformedCookieErrorCode);
+          expect((error as InputError).message).toEqual(
+            "Cookie 'ic_env' is not valid URI-encoded content",
+          );
+        }
       });
 
       test('should return undefined from safeGetCanisterEnv when copies disagree', () => {

--- a/packages/core/src/agent/canister-env/index.test.ts
+++ b/packages/core/src/agent/canister-env/index.test.ts
@@ -6,6 +6,7 @@ import {
   EmptyCookieErrorCode,
   MissingRootKeyErrorCode,
   MissingCookieErrorCode,
+  ConflictingCanisterEnvErrorCode,
 } from '../errors.ts';
 import { JSDOM } from 'jsdom';
 
@@ -152,6 +153,85 @@ describe('getCanisterEnv', () => {
         const env = getCanisterEnv<TestCanisterEnv>();
 
         expect(env.PUBLIC_MESSAGE).toBe(specialChars);
+      });
+    });
+
+    describe('duplicate cookies', () => {
+      test('should accept several identical copies of the cookie', () => {
+        const cookieValue = `ic_root_key=${mockRootKeyHex}&PUBLIC_CANISTER_ID:backend=abc`;
+        const encoded = encodeURIComponent(cookieValue);
+
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=${encoded}; ic_env=${encoded}`,
+        });
+
+        const env = getCanisterEnv();
+
+        expect(bytesToHex(env.IC_ROOT_KEY)).toBe(mockRootKeyHex);
+      });
+
+      test('should accept copies that differ only in variable order or encoding', () => {
+        // `encodeURIComponent` leaves `_` alone, while the asset canister percent-encodes every
+        // non-alphanumeric character. Both decode to the same environment.
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: [
+            `ic_env=${encodeURIComponent(`ic_root_key=${mockRootKeyHex}&PUBLIC_CANISTER_ID:backend=abc`)}`,
+            `ic_env=${encodeURIComponent(`PUBLIC_CANISTER_ID:backend=abc&ic_root_key=${mockRootKeyHex}`).replace(/_/g, '%5F')}`,
+          ].join('; '),
+        });
+
+        const env = getCanisterEnv();
+
+        expect(bytesToHex(env.IC_ROOT_KEY)).toBe(mockRootKeyHex);
+      });
+
+      test('should throw instead of picking one when copies disagree', () => {
+        const stale = `ic_root_key=${mockRootKeyHex}&PUBLIC_CANISTER_ID:backend=stale-id`;
+        const fresh = `ic_root_key=${mockRootKeyHex}&PUBLIC_CANISTER_ID:backend=fresh-id`;
+
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=${encodeURIComponent(stale)}; ic_env=${encodeURIComponent(fresh)}`,
+        });
+
+        expect.assertions(4);
+        try {
+          getCanisterEnv();
+        } catch (error) {
+          expect(error).toBeInstanceOf(InputError);
+          expect((error as InputError).code).toBeInstanceOf(ConflictingCanisterEnvErrorCode);
+          expect((error as ConflictingCanisterEnvErrorCode & InputError).message).toContain(
+            "Found 2 'ic_env' cookies with conflicting values",
+          );
+          expect((error as InputError).code).toHaveProperty('values', [stale, fresh]);
+        }
+      });
+
+      test('should not confuse a cookie whose name merely shares a prefix', () => {
+        const cookieValue = `ic_root_key=${mockRootKeyHex}`;
+
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env_backup=${encodeURIComponent('ic_root_key=deadbeef')}; ic_env=${encodeURIComponent(cookieValue)}`,
+        });
+
+        const env = getCanisterEnv();
+
+        expect(bytesToHex(env.IC_ROOT_KEY)).toBe(mockRootKeyHex);
+      });
+
+      test('should return undefined from safeGetCanisterEnv when copies disagree', () => {
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: [
+            `ic_env=${encodeURIComponent(`ic_root_key=${mockRootKeyHex}&PUBLIC_CANISTER_ID:backend=a`)}`,
+            `ic_env=${encodeURIComponent(`ic_root_key=${mockRootKeyHex}&PUBLIC_CANISTER_ID:backend=b`)}`,
+          ].join('; '),
+        });
+
+        expect(safeGetCanisterEnv()).toBeUndefined();
       });
     });
 

--- a/packages/core/src/agent/canister-env/index.test.ts
+++ b/packages/core/src/agent/canister-env/index.test.ts
@@ -243,6 +243,40 @@ describe('getCanisterEnv', () => {
         }
       });
 
+      test('should detect a conflict that only repeated variables reveal', () => {
+        // Both copies hold the same variables, so sorting them raw would compare equal. They
+        // resolve differently though, because the last occurrence of a repeated variable wins.
+        const first = `ic_root_key=${mockRootKeyHex}&PUBLIC_ID=a&PUBLIC_ID=b`;
+        const second = `ic_root_key=${mockRootKeyHex}&PUBLIC_ID=b&PUBLIC_ID=a`;
+
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=${encodeURIComponent(first)}; ic_env=${encodeURIComponent(second)}`,
+        });
+
+        expect.assertions(2);
+        try {
+          getCanisterEnv();
+        } catch (error) {
+          expect((error as InputError).code).toBeInstanceOf(ConflictingCanisterEnvErrorCode);
+          expect((error as InputError).message).toContain('Found 2 conflicting values');
+        }
+      });
+
+      test('should treat repeated variables in a consistent order as one environment', () => {
+        const cookieValue = `ic_root_key=${mockRootKeyHex}&PUBLIC_ID=a&PUBLIC_ID=b`;
+        const encoded = encodeURIComponent(cookieValue);
+
+        Object.defineProperty(globalThis.document, 'cookie', {
+          writable: true,
+          value: `ic_env=${encoded}; ic_env=${encoded}`,
+        });
+
+        const env = getCanisterEnv<{ readonly PUBLIC_ID: string }>();
+
+        expect(env.PUBLIC_ID).toBe('b');
+      });
+
       test('should ignore a copy with malformed encoding when a valid one is present', () => {
         const cookieValue = `ic_root_key=${mockRootKeyHex}`;
 

--- a/packages/core/src/agent/canister-env/index.ts
+++ b/packages/core/src/agent/canister-env/index.ts
@@ -11,6 +11,7 @@ import {
   EmptyCookieErrorCode,
   MissingRootKeyErrorCode,
   MissingCookieErrorCode,
+  ConflictingCanisterEnvErrorCode,
 } from '../errors.ts';
 
 const IC_ENV_COOKIE_NAME = 'ic_env';
@@ -91,6 +92,7 @@ export interface GetCanisterEnvOptions {
  * @returns The environment variables for the asset canister, always including `IC_ROOT_KEY`
  * @throws {TypeError} When `globalThis.document` is not available
  * @throws {InputError} When the cookie is not found
+ * @throws {InputError} When several cookies with that name are present and they disagree
  * @throws {InputError} When the `IC_ROOT_KEY` is missing or has an invalid length
  * @see The {@link https://js.icp.build/core/latest/canister-environment/ | Canister Environment Guide} for more details on how to use the canister environment in a frontend application
  * @experimental
@@ -113,17 +115,25 @@ export function getCanisterEnv<T = Record<string, never>>(
 ): CanisterEnv & T {
   const { cookieName = IC_ENV_COOKIE_NAME } = options;
 
-  const cookie = getCookie(cookieName);
-  if (!cookie) {
+  const cookieValues = getCookieValues(cookieName);
+  if (cookieValues.length === 0) {
     throw InputError.fromCode(new MissingCookieErrorCode(cookieName));
   }
 
-  const cookieValue = cookie.split('=')[1].trim();
-  if (!cookieValue) {
+  // Several cookies with the same name can coexist on one origin, since a cookie is keyed
+  // on (name, domain, path) and partitioned cookies live in their own jar. Picking one of
+  // them arbitrarily silently configures the app against the wrong network or canister, so
+  // only proceed when every copy agrees.
+  const distinctValues = distinctEnvValues(cookieValues.map(decodeURIComponent));
+  if (distinctValues.length > 1) {
+    throw InputError.fromCode(new ConflictingCanisterEnvErrorCode(cookieName, distinctValues));
+  }
+
+  const decodedCookieValue = distinctValues[0];
+  if (!decodedCookieValue) {
     throw InputError.fromCode(new EmptyCookieErrorCode(cookieName));
   }
 
-  const decodedCookieValue = decodeURIComponent(cookieValue);
   const envVars = parseEnvVars<T>(decodedCookieValue);
   if (!envVars.IC_ROOT_KEY) {
     throw InputError.fromCode(new MissingRootKeyErrorCode());
@@ -163,10 +173,36 @@ export function safeGetCanisterEnv<T = Record<string, never>>(
   }
 }
 
-function getCookie(cookieName: string): string | undefined {
+function getCookieValues(cookieName: string): string[] {
+  const prefix = `${cookieName}=`;
+
   return globalThis.document.cookie
     .split(';')
-    .find(cookie => cookie.trim().startsWith(`${cookieName}=`));
+    .map(cookie => cookie.trim())
+    .filter(cookie => cookie.startsWith(prefix))
+    .map(cookie => cookie.slice(prefix.length).trim());
+}
+
+/**
+ * Deduplicate cookie values that carry the same environment, keeping the first occurrence of each.
+ *
+ * Comparing the decoded strings directly would report false conflicts, because writers legitimately
+ * differ in how they percent-encode (`_` vs `%5F`) and in the order they emit variables. Sorting the
+ * variables makes the comparison independent of both.
+ * @param decodedValues The decoded values of every cookie carrying the environment
+ * @returns One value per distinct environment, in the order the browser listed them
+ */
+function distinctEnvValues(decodedValues: string[]): string[] {
+  const byCanonicalForm = new Map<string, string>();
+
+  for (const value of decodedValues) {
+    const canonicalForm = value.split(ENV_VAR_SEPARATOR).sort().join(ENV_VAR_SEPARATOR);
+    if (!byCanonicalForm.has(canonicalForm)) {
+      byCanonicalForm.set(canonicalForm, value);
+    }
+  }
+
+  return Array.from(byCanonicalForm.values());
 }
 
 function parseEnvVars<T = Record<string, never>>(decoded: string): CanisterEnv & T {

--- a/packages/core/src/agent/canister-env/index.ts
+++ b/packages/core/src/agent/canister-env/index.ts
@@ -222,7 +222,7 @@ function distinctEnvValues(decodedValues: string[]): string[] {
   const byCanonicalForm = new Map<string, string>();
 
   for (const value of decodedValues) {
-    const canonicalForm = value.split(ENV_VAR_SEPARATOR).sort().join(ENV_VAR_SEPARATOR);
+    const canonicalForm = canonicalEnvForm(value);
     if (!byCanonicalForm.has(canonicalForm)) {
       byCanonicalForm.set(canonicalForm, value);
     }
@@ -231,14 +231,35 @@ function distinctEnvValues(decodedValues: string[]): string[] {
   return Array.from(byCanonicalForm.values());
 }
 
-function parseEnvVars<T = Record<string, never>>(decoded: string): CanisterEnv & T {
-  const entries = decoded.split(ENV_VAR_SEPARATOR).map(v => {
+/**
+ * Render the environment a cookie value resolves to, in a form that is stable across writers.
+ *
+ * Resolving repeated variables the way {@link parseEnvVars} does — last occurrence wins — before
+ * sorting is what makes this reflect the *effective* environment. Sorting the raw variables instead
+ * would make `A=1&A=2` and `A=2&A=1` compare equal despite resolving to different values for `A`,
+ * which would suppress a genuine conflict.
+ * @param decoded The decoded value of a single cookie
+ * @returns A canonical rendering of the environment it resolves to
+ */
+function canonicalEnvForm(decoded: string): string {
+  const resolved = new Map(splitEnvVars(decoded));
+
+  return Array.from(resolved, ([key, value]) => `${key}${ENV_VAR_ASSIGNMENT_SYMBOL}${value}`)
+    .sort()
+    .join(ENV_VAR_SEPARATOR);
+}
+
+function splitEnvVars(decoded: string): [string, string][] {
+  return decoded.split(ENV_VAR_SEPARATOR).map(v => {
     // we only want to split at the first occurrence of the assignment symbol
     const symbolIndex = v.indexOf(ENV_VAR_ASSIGNMENT_SYMBOL);
 
-    const key = v.slice(0, symbolIndex);
-    const value = v.substring(symbolIndex + 1);
+    return [v.slice(0, symbolIndex), v.substring(symbolIndex + 1)];
+  });
+}
 
+function parseEnvVars<T = Record<string, never>>(decoded: string): CanisterEnv & T {
+  const entries = splitEnvVars(decoded).map(([key, value]) => {
     if (key === IC_ROOT_KEY_VALUE_NAME) {
       const rootKey = hexToBytes(value);
       if (rootKey.length !== IC_ROOT_KEY_BYTES_LENGTH) {

--- a/packages/core/src/agent/canister-env/index.ts
+++ b/packages/core/src/agent/canister-env/index.ts
@@ -12,6 +12,7 @@ import {
   MissingRootKeyErrorCode,
   MissingCookieErrorCode,
   ConflictingCanisterEnvErrorCode,
+  MalformedCookieErrorCode,
 } from '../errors.ts';
 
 const IC_ENV_COOKIE_NAME = 'ic_env';
@@ -92,6 +93,7 @@ export interface GetCanisterEnvOptions {
  * @returns The environment variables for the asset canister, always including `IC_ROOT_KEY`
  * @throws {TypeError} When `globalThis.document` is not available
  * @throws {InputError} When the cookie is not found
+ * @throws {InputError} When no copy of the cookie holds valid URI-encoded content
  * @throws {InputError} When several cookies with that name are present and they disagree
  * @throws {InputError} When the `IC_ROOT_KEY` is missing or has an invalid length
  * @see The {@link https://js.icp.build/core/latest/canister-environment/ | Canister Environment Guide} for more details on how to use the canister environment in a frontend application
@@ -124,7 +126,14 @@ export function getCanisterEnv<T = Record<string, never>>(
   // on (name, domain, path) and partitioned cookies live in their own jar. Picking one of
   // them arbitrarily silently configures the app against the wrong network or canister, so
   // only proceed when every copy agrees.
-  const distinctValues = distinctEnvValues(cookieValues.map(decodeURIComponent));
+  const decodedValues = cookieValues
+    .map(decodeCookieValue)
+    .filter((value): value is string => value !== undefined);
+  if (decodedValues.length === 0) {
+    throw InputError.fromCode(new MalformedCookieErrorCode(cookieName));
+  }
+
+  const distinctValues = distinctEnvValues(decodedValues);
   if (distinctValues.length > 1) {
     throw InputError.fromCode(new ConflictingCanisterEnvErrorCode(cookieName, distinctValues));
   }
@@ -173,6 +182,23 @@ export function safeGetCanisterEnv<T = Record<string, never>>(
   }
 }
 
+/**
+ * Decode one cookie value, or return `undefined` when its percent-encoding is malformed.
+ *
+ * A corrupt copy carries no environment, so it is not a candidate to choose between: dropping it
+ * lets a valid sibling still be used, rather than having `decodeURIComponent` throw a bare
+ * `URIError` out of the whole call.
+ * @param value The raw, still-encoded value of a single cookie
+ * @returns The decoded value, or `undefined` if it cannot be decoded
+ */
+function decodeCookieValue(value: string): string | undefined {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function getCookieValues(cookieName: string): string[] {
   const prefix = `${cookieName}=`;
 
@@ -186,9 +212,9 @@ function getCookieValues(cookieName: string): string[] {
 /**
  * Deduplicate cookie values that carry the same environment, keeping the first occurrence of each.
  *
- * Comparing the decoded strings directly would report false conflicts, because writers legitimately
- * differ in how they percent-encode (`_` vs `%5F`) and in the order they emit variables. Sorting the
- * variables makes the comparison independent of both.
+ * Decoding has already normalised the writers' differing percent-encoding (`_` vs `%5F`). What it
+ * does not normalise is the order variables are emitted in, which differs between writers too, so
+ * compare on a form with the variables sorted rather than on the decoded string itself.
  * @param decodedValues The decoded values of every cookie carrying the environment
  * @returns One value per distinct environment, in the order the browser listed them
  */

--- a/packages/core/src/agent/errors.ts
+++ b/packages/core/src/agent/errors.ts
@@ -952,6 +952,19 @@ export class EmptyCookieErrorCode extends ErrorCode {
   }
 }
 
+export class MalformedCookieErrorCode extends ErrorCode {
+  public name = 'MalformedCookieErrorCode';
+
+  constructor(public readonly expectedCookieName: string) {
+    super();
+    Object.setPrototypeOf(this, MalformedCookieErrorCode.prototype);
+  }
+
+  public toErrorMessage(): string {
+    return `Cookie '${this.expectedCookieName}' is not valid URI-encoded content`;
+  }
+}
+
 export class ConflictingCanisterEnvErrorCode extends ErrorCode {
   public name = 'ConflictingCanisterEnvErrorCode';
 
@@ -964,7 +977,7 @@ export class ConflictingCanisterEnvErrorCode extends ErrorCode {
   }
 
   public toErrorMessage(): string {
-    return `Found ${this.values.length} '${this.expectedCookieName}' cookies with conflicting values. This usually means a stale cookie from a previous deployment is still present on this origin. Clear the site data for this origin and reload.`;
+    return `Found ${this.values.length} conflicting values for the '${this.expectedCookieName}' cookie. This usually means a stale cookie from a previous deployment is still present on this origin. Clear the site data for this origin and reload.`;
   }
 }
 

--- a/packages/core/src/agent/errors.ts
+++ b/packages/core/src/agent/errors.ts
@@ -952,6 +952,22 @@ export class EmptyCookieErrorCode extends ErrorCode {
   }
 }
 
+export class ConflictingCanisterEnvErrorCode extends ErrorCode {
+  public name = 'ConflictingCanisterEnvErrorCode';
+
+  constructor(
+    public readonly expectedCookieName: string,
+    public readonly values: string[],
+  ) {
+    super();
+    Object.setPrototypeOf(this, ConflictingCanisterEnvErrorCode.prototype);
+  }
+
+  public toErrorMessage(): string {
+    return `Found ${this.values.length} '${this.expectedCookieName}' cookies with conflicting values. This usually means a stale cookie from a previous deployment is still present on this origin. Clear the site data for this origin and reload.`;
+  }
+}
+
 export class EffectiveSubnetIdAsyncErrorCode extends ErrorCode {
   public name = 'EffectiveSubnetIdAsyncErrorCode';
 


### PR DESCRIPTION
Closes #1384.

## Problem

`getCanisterEnv` resolved the environment with:

```ts
document.cookie.split(';').find(cookie => cookie.trim().startsWith(`${cookieName}=`));
```

Several `ic_env` cookies can coexist on one origin — a cookie is keyed on (name, domain, path), and partitioned cookies live in their own jar. The realistic trigger is a frontend canister upgraded between asset canister implementations that disagree on `Partitioned`: `dfinity/sdk`'s `ic-certified-assets` writes `SameSite=Lax`, `dfinity/certified-assets` writes `Secure; SameSite=None; Partitioned` (confirmed against the live header on `skills.internetcomputer.org`). The two land in different jars on the same host and both stay readable.

The issue framed this as "whichever the browser happens to list first", but the order is specified: RFC 6265 §5.4 lists longer paths first and, among equal paths, **earlier creation-times first**. So first-match isn't arbitrary — it systematically prefers the *stalest* copy. The app is then configured against a canister that may no longer exist, and the resulting call rejection names nothing about cookies, so it reads as a broken replica.

## Change

Collect every copy. Identical copies are common and stay silent; when they disagree, throw a new `ConflictingCanisterEnvErrorCode` naming the conflict. `safeGetCanisterEnv` keeps returning `undefined`.

No precedence rule is invented, deliberately. Sorting by `Path` or `Partitioned` isn't possible here — `document.cookie` exposes only `name=value`, and the attributes aren't there. `cookieStore.getAll()` would have them but is Chromium-only. And "prefer the non-partitioned copy" would be backwards: the authoritative mainnet writer *is* the partitioned one. Conflicting boot config is a broken environment; guessing is what produced the bug.

Copies are compared on the environment they *resolve to*, not on their text, because writers differ in ways that carry no meaning. Decoding handles percent-encoding — `encodeURIComponent` leaves `_` alone while the asset canister encodes it as `%5F`. Resolving repeated variables last-wins (as `parseEnvVars` does) and then sorting handles emission order. Comparing raw or merely-decoded strings would report false conflicts between an asset canister and a dev server serving the *same* environment, which would be worse than the bug being fixed; sorting raw variables without resolving repeats would do the opposite and mask a real difference.

A copy whose percent-encoding is malformed can't be decoded at all. It carries no environment, so it isn't a second candidate to choose between — it's dropped, letting a valid sibling still be used, and `MalformedCookieErrorCode` is reported only when no copy survives. This also keeps `decodeURIComponent`'s `URIError` from escaping an API that documents `InputError`.

Also replaces `cookie.split('=')[1]`, which truncated any value containing an unencoded `=`, with the same first-separator slice `parseEnvVars` already used. It failed closed (`MissingRootKeyErrorCode`), so this is robustness rather than a fix.

## Scope

Deliberately minimal. The investigation on #1384 also considered aligning cookie attributes across `dfinity/certified-assets`, `dfinity/candid`, `dfinity/sdk` and ~38 dev-server configs. That's dropped: local frontends are served at `http://<canister-id>.localhost:8000/` and these are host-only cookies, so the dev-server/asset-canister collision that would have justified it doesn't occur. This reader change is also the only one that reaches canisters and projects already deployed — every writer change is upgrade-gated.

No new public functions — the only additions to the surface are the two error codes. `getAllCanisterEnvs` was considered as an escape hatch and left out until someone needs it.

## Testing

Ten tests added: identical copies; copies differing only in encoding or variable order; disagreeing copies; three cookies holding two environments (pinning the count in the message); copies whose difference only repeated variables reveal; repeated variables in a consistent order resolving last-wins as one environment; a cookie whose name merely shares a prefix (`ic_env_backup`); a malformed copy alongside a valid one; no decodable copy at all; and the `safeGetCanisterEnv` path. Full suite green (646 passed, 36 snapshots), typecheck and lint clean.

The module is `@experimental`, so the behaviour change — throwing where it previously returned a guess — is in budget. It strictly dominates silently building an actor against a dead canister.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

